### PR TITLE
Compile ApiSetMap.c when -antidebug flag is set

### DIFF
--- a/PEzor.sh
+++ b/PEzor.sh
@@ -381,10 +381,14 @@ case $OUTPUT_FORMAT in
             SOURCES="$SOURCES $TMP_DIR/ReflectiveLoader.o"
         fi
 
-        if [ $UNHOOK = true ]; then
+        if [ $UNHOOK = true ] || [ $ANTIDEBUG = true ]; then
             $CC $CCFLAGS -c $INSTALL_DIR/ApiSetMap.c -o $TMP_DIR/ApiSetMap.o &&
-            $CC $CCFLAGS -c $INSTALL_DIR/loader.c -o $TMP_DIR/loader.o
-            SOURCES="$SOURCES $TMP_DIR/ApiSetMap.o $TMP_DIR/loader.o"
+            SOURCES="$SOURCES $TMP_DIR/ApiSetMap.o"
+        fi
+
+        if [ $UNHOOK = true ]; then
+            $CC $CCFLAGS -c $INSTALL_DIR/loader.c -o $TMP_DIR/loader.o &&
+            SOURCES="$SOURCES $TMP_DIR/loader.o"
         fi
 
         $CXX $CPPFLAGS $CXXFLAGS $INSTALL_DIR/*.cpp $TMP_DIR/{shellcode,sleep}.cpp $SOURCES -o $BLOB.packed.$OUTPUT_EXTENSION &&


### PR DESCRIPTION
If -unhook flag is not set, ApiSetMap.c does not compile and an error is thrown if -antidebug flag is set:

```
$ cat ./PEzor.sh | tail -n +384 | head -n 5
        if [ $UNHOOK = true ]; then
            $CC $CCFLAGS -c $INSTALL_DIR/ApiSetMap.c -o $TMP_DIR/ApiSetMap.o &&
            $CC $CCFLAGS -c $INSTALL_DIR/loader.c -o $TMP_DIR/loader.o
            SOURCES="$SOURCES $TMP_DIR/ApiSetMap.o $TMP_DIR/loader.o"
        fi

$ ./PEzor.sh -format=exe -antidebug shellcode.bin
 ________________
< PEzor!! v2.1.0 >
 ----------------
[?] Output format: exe
[?] Anti-debug enabled
[?] Processing shellcode.bin
[?] Shellcode detected
[?] Building executable
/usr/bin/x86_64-w64-mingw32-ld: /tmp/PEzor-fede9e.o:PEzor.cpp:(.text+0x2a): undefined reference to `GetProcessEnvironmentBlock'
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```

GetProcessEnvironmentBlock is defined in ApiSetMap.c and used in PEzor.cpp (anti_debug function):

```
$ grep -Rn GetProcessEnvironmentBlock .
./PEzor.cpp:31:    __PPEB peb = GetProcessEnvironmentBlock();
./ApiSetMap.c:34:__PPEB GetProcessEnvironmentBlock()
./ApiSetMap.c:52:    return (__PLDR_DATA_TABLE_ENTRY)GetProcessEnvironmentBlock()->pLdr->InMemoryOrderModuleList.Flink;
./ApiSetMap.c:58:    pApiSetMap = (PAPI_SET_NAMESPACE_ARRAY_V2)GetProcessEnvironmentBlock()->lpApiSetMap;
./ApiSetMap.c:83:    pApiSetMap = (PAPI_SET_NAMESPACE_ARRAY_V6)GetProcessEnvironmentBlock()->lpApiSetMap;
./ApiSetMap.c:130:    pApiSetMap = (PAPI_SET_NAMESPACE_ARRAY_V4)GetProcessEnvironmentBlock()->lpApiSetMap;
./ApiSetMap.c:170:    pApiSetMap = (PAPI_SET_NAMESPACE_ARRAY_V2)GetProcessEnvironmentBlock()->lpApiSetMap;
./ApiSetMap.h:160:__PPEB GetProcessEnvironmentBlock();
```

The pull request proposes to change the previous 5 lines of code for these:

```
$ cat ./PEzor.sh | tail -n +384 | head -n 9
        if [ $UNHOOK = true ] || [ $ANTIDEBUG = true ]; then
            $CC $CCFLAGS -c $INSTALL_DIR/ApiSetMap.c -o $TMP_DIR/ApiSetMap.o &&
            SOURCES="$SOURCES $TMP_DIR/ApiSetMap.o"
        fi

        if [ $UNHOOK = true ]; then
            $CC $CCFLAGS -c $INSTALL_DIR/loader.c -o $TMP_DIR/loader.o &&
            SOURCES="$SOURCES $TMP_DIR/loader.o"
        fi

$ ./PEzor.sh -format=exe -antidebug shellcode.bin
 ________________
< PEzor!! v2.1.0 >
 ----------------
[?] Output format: exe
[?] Anti-debug enabled
[?] Processing shellcode.bin
[?] Shellcode detected
[?] Building executable
[!] Done! Check shellcode.bin.packed.exe: PE32+ executable (console) x86-64 (stripped to external PDB), for MS Windows
```