### PR TITLE
Prevent executables from spawning a console

### DIFF
--- a/PEzor.sh
+++ b/PEzor.sh
@@ -355,8 +355,14 @@ case $OUTPUT_FORMAT in
             echo 'unsigned int buf_size = sizeof(buf);' >> $TMP_DIR/shellcode.cpp || exit 1
         fi
 
-        CCFLAGS="-O3 -Wl,-strip-all -Wall -pedantic"
-        CPPFLAGS="-O3 -Wl,-strip-all -Wall -pedantic"
+        if [[ ( $OUTPUT_FORMAT = "exe" || $OUTPUT_FORMAT = "service-exe" ) && $DEBUG = false ]]; then
+            CCFLAGS="-O3 -Wl,-strip-all,-subsystem=windows -Wall -pedantic"
+            CPPFLAGS="-O3 -Wl,-strip-all,-subsystem=windows -Wall -pedantic"
+        else
+            CCFLAGS="-O3 -Wl,-strip-all, -Wall -pedantic"
+            CPPFLAGS="-O3 -Wl,-strip-all, -Wall -pedantic"
+        fi
+
         CXXFLAGS="-std=c++17 -static"
 
         if [ $BITS -eq 32 ]; then


### PR DESCRIPTION
Hi, 

I put in a fix to prevent executables generated by PEzor from spawning a console, which is mentioned in #52.

I did not go with the solution suggested in this issue (`FreeConsole()`) since that route still spawns a console, it just quickly hides it. Another solution would have been to call `ShowWindow(GetConsoleWindow(), SW_HIDE);`, but this has the same effect as `FreeConsole()`

My solution is to pass the `-subsystem=windows` flag to the linked upon compilation to compile as a GUI Application instead of Console Application.

I applied this fix to both "exe" as well as "service-exe". I'm not sure if it's necessary in the last case.. I also made sure that debug builds don't compile with this flag.