### PR TITLE
Cast executor to void ptr in the INLINE_SYSCALLS(NtCreateThreadEx) call.

### DIFF
--- a/inject.cpp
+++ b/inject.cpp
@@ -234,7 +234,7 @@ LPVOID inject_shellcode_self(unsigned char shellcode[], SIZE_T size, PHANDLE phT
                 THREAD_ALL_ACCESS,
                 nullptr,
                 (HANDLE)-1,
-                executor,
+                (void*)executor,
                 allocation,
                 THREAD_CREATE_FLAGS_HIDE_FROM_DEBUGGER,
                 0,


### PR DESCRIPTION
PEzor/inject.cpp:232:22: error: no matching function for call to object of type '::jm::syscall_function<decltype(NtCreateThreadEx)>' (aka 'syscall_function<long (void **, unsigned long, _OBJECT_ATTRIBUTES *, void *, void *, void *, unsigned long, unsigned long long, unsigned long long, unsigned long long, _PS_ATTRIBUTE_LIST *)>')