### PR TITLE
disable GO111MODULE

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 
+go env -w GO111MODULE=off
 CURR_DIR=`pwd`
 INSTALL_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 


### PR DESCRIPTION
Fix error
```
go: go.mod file not found in current directory or any parent directory; see 'go help modules' 
```
when executing 
```bash
go get github.com/EgeBalci/sgn &&
```