### PR TITLE
Fix sgn install command

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -34,7 +34,7 @@ make install &&
 cd ../..)
 ) &&
 
-go get github.com/EgeBalci/sgn &&
+go install github.com/EgeBalci/sgn@latest &&
 
 (ls wclang 2>/dev/null 1>&2 || (git clone --depth 1 https://github.com/tpoechtrager/wclang.git &&
 cd wclang &&


### PR DESCRIPTION
The `go get` command for installing go binaries was deprecated in favor of `go install`. Therefore, `go install github.com/EgeBalci/sgn@latest` should be used to install `sgn`.

See https://github.com/EgeBalci/sgn/pull/15.