### PR TITLE
Switch to the new go install command

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -34,7 +34,7 @@ make install &&
 cd ../..)
 ) &&
 
-go get github.com/EgeBalci/sgn &&
+go install github.com/EgeBalci/sgn@latest &&
 
 (ls wclang 2>/dev/null 1>&2 || (git clone --depth 1 https://github.com/tpoechtrager/wclang.git &&
 cd wclang &&


### PR DESCRIPTION
Hello,

The command "go get" was deprecated.
I changed the install script it use the new command,