### PR TITLE
Update PEzor.sh

### DIFF
--- a/PEzor.sh
+++ b/PEzor.sh
@@ -397,7 +397,7 @@ case $OUTPUT_FORMAT in
 
             if [ $SGN = true ]; then
                 echo '[?] Executing sgn' &&
-                (sgn -a $BITS -c 1 -o $TMP_DIR/shellcode.bin $TMP_DIR/shellcode.bin.donut || exit 1)
+                (sgn -a $BITS -c 1 -o $TMP_DIR/shellcode.bin -i $TMP_DIR/shellcode.bin.donut || exit 1)
             else
                 cp $TMP_DIR/shellcode.bin.donut $TMP_DIR/shellcode.bin
             fi &&


### PR DESCRIPTION
I noticed sgn was not working and upon reviewing the source the latest sgn uses -i for the input shellcode and PEzor.sh is missing the -i flag.